### PR TITLE
fix(dispatcher): allow /us/en-word.html

### DIFF
--- a/dispatcher/src/conf.dispatcher.d/filters/filters.any
+++ b/dispatcher/src/conf.dispatcher.d/filters/filters.any
@@ -38,3 +38,7 @@ $include "./default_filters.any"
 /0201 { /type "allow" /url "/home/users/*.infinity.json" }
 
 /0202 { /type "deny" /url "*us/en-word*" }
+
+# Allow /us/en-word.html (fix for 404 - overrides /0202)
+/0203 { /type "allow" /url "/us/en-word.html" }
+


### PR DESCRIPTION
## Summary

Detailed explanation: The root cause of the 404 error on /us/en-word.html was a deny filter (/0202) blocking URLs containing 'us/en-word'. By adding an explicit allow filter (/0203) for /us/en-word.html immediately after the deny filter, the dispatcher configuration now permits requests to /us/en-word.html, resolving the issue while maintaining all existing rules and structure.

## Files Changed

- `dispatcher/src/conf.dispatcher.d/filters/filters.any`

## Diff Preview

```diff
--- a/dispatcher/src/conf.dispatcher.d/filters/filters.any
+++ b/dispatcher/src/conf.dispatcher.d/filters/filters.any
@@ -38,3 +38,7 @@
 /0201 { /type "allow" /url "/home/users/*.infinity.json" }
 
 /0202 { /type "deny" /url "*us/en-word*" }
+
+# Allow /us/en-word.html (fix for 404 - overrides /0202)
+/0203 { /type "allow" /url "/us/en-word.html" }
+

```

---
*Generated by AEM Edge Troubleshooter*