### PR TITLE
fix(dispatcher): allow /us/en-word.html

### DIFF
--- a/dispatcher/src/conf.dispatcher.d/filters/filters.any
+++ b/dispatcher/src/conf.dispatcher.d/filters/filters.any
@@ -38,3 +38,6 @@ $include "./default_filters.any"
 /0201 { /type "allow" /url "/home/users/*.infinity.json" }
 
 /0202 { /type "deny" /url "*us/en-word*" }
+
+# Allow /us/en-word.html (fix for 404 - overrides /0202)
+/0203 { /type "allow" /url "/us/en-word.html" }


### PR DESCRIPTION
## Summary

Detailed explanation: The root cause was that rule /0202 in dispatcher/src/conf.dispatcher.d/filters/filters.any denies all URLs matching *us/en-word*, causing legitimate requests to /us/en-word.html to return 404. The fix adds an explicit allow rule (/0203) for /us/en-word.html directly after the deny rule, ensuring that Dispatcher will allow this request, resolving the 404 error while preserving all existing filter rules.

## Files Changed

- `dispatcher/src/conf.dispatcher.d/filters/filters.any`

## Diff Preview

```diff
--- a/dispatcher/src/conf.dispatcher.d/filters/filters.any
+++ b/dispatcher/src/conf.dispatcher.d/filters/filters.any
@@ -38,3 +38,6 @@
 /0201 { /type "allow" /url "/home/users/*.infinity.json" }
 
 /0202 { /type "deny" /url "*us/en-word*" }
+
+# Allow /us/en-word.html (fix for 404 - overrides /0202)
+/0203 { /type "allow" /url "/us/en-word.html" }

```

---
*Generated by AEM Edge Troubleshooter*