### PR TITLE
fix(dispatcher): allow /us/en-word.html

### DIFF
--- a/dispatcher/src/conf.dispatcher.d/filters/filters.any
+++ b/dispatcher/src/conf.dispatcher.d/filters/filters.any
@@ -38,3 +38,6 @@ $include "./default_filters.any"
 /0201 { /type "allow" /url "/home/users/*.infinity.json" }
 
 /0202 { /type "deny" /url "*us/en-word*" }
+
+# Allow /us/en-word.html (fix for 404 - overrides /0202)
+/0203 { /type "allow" /url "/us/en-word.html" }


### PR DESCRIPTION
## Summary

Detailed explanation: Root cause was that deny rule /0202 ('*us/en-word*') in filters.any was blocking access to /us/en-word.html, resulting in a 404. Fix adds an explicit allow rule (/0203) for /us/en-word.html directly after the deny rule, ensuring the request is allowed and resolving the 404 error for this path.

## Files Changed

- `dispatcher/src/conf.dispatcher.d/filters/filters.any`

## Diff Preview

```diff
--- a/dispatcher/src/conf.dispatcher.d/filters/filters.any
+++ b/dispatcher/src/conf.dispatcher.d/filters/filters.any
@@ -38,3 +38,6 @@
 /0201 { /type "allow" /url "/home/users/*.infinity.json" }
 
 /0202 { /type "deny" /url "*us/en-word*" }
+
+# Allow /us/en-word.html (fix for 404 - overrides /0202)
+/0203 { /type "allow" /url "/us/en-word.html" }

```

---
*Generated by AEM Dispatcher Agent*